### PR TITLE
Fix course period edit view path

### DIFF
--- a/app/Http/Controllers/CoursePeriodController.php
+++ b/app/Http/Controllers/CoursePeriodController.php
@@ -91,7 +91,7 @@ class CoursePeriodController extends Controller
             abort(404, 'Periode tidak ditemukan untuk kursus ini.');
         }
 
-        return view('course-periods.edit', compact('course', 'period'));
+        return view('courses-period.edit', compact('course', 'period'));
     }
 
     /**


### PR DESCRIPTION
## Summary
- point CoursePeriodController edit method to the correct `courses-period.edit` view

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing because dependencies could not be installed; `composer install` blocked by network 403)*


------
https://chatgpt.com/codex/tasks/task_e_68998c0cdac08324b1442b69f9c3eca5