### PR TITLE
test: assert login fails with redirect and error

### DIFF
--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -34,10 +34,17 @@ class AuthenticationTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $this->post('/login', [
+        $response = $this->from('/login')->post('/login', [
             'email' => $user->email,
             'password' => 'wrong-password',
         ]);
+
+        $response->assertRedirect('/login');
+        $response->assertSessionHasErrors('email');
+        $this->assertSame(
+            trans('auth.failed'),
+            session('errors')->get('email')[0]
+        );
 
         $this->assertGuest();
     }


### PR DESCRIPTION
## Summary
- verify failed login redirects back to login route and flashes email error

## Testing
- `php artisan test tests/Feature/Auth/AuthenticationTest.php` *(fails: Failed opening required '/workspace/LMSAPP_Laravel_V2/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading https://mirrors.cloud.tencent.com/repository/composer/voku/portable-ascii/2.0.3/voku-portable-ascii-2.0.3.zip: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68998c12b8dc8324acf44965cc97aa85