### PR TITLE
Verify event organizer assignment

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -216,7 +216,7 @@ class User extends Authenticatable
      */
     public function isEventOrganizerFor(Course $course): bool
     {
-        return $this->hasRole('event-organizer');
+        return $course->eventOrganizers()->where('user_id', $this->id)->exists();
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure `User::isEventOrganizerFor` confirms the user organizes the given course

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: curl error 56 when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68998c0fcb788324b533f4312b929a4a