### PR TITLE
Add course feature tests and factories

### DIFF
--- a/database/factories/ContentFactory.php
+++ b/database/factories/ContentFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Content;
+use App\Models\Lesson;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Content>
+ */
+class ContentFactory extends Factory
+{
+    protected $model = Content::class;
+
+    public function definition(): array
+    {
+        return [
+            'lesson_id' => Lesson::factory(),
+            'title' => $this->faker->sentence(),
+            'type' => 'text',
+            'body' => $this->faker->paragraph(),
+            'file_path' => null,
+            'order' => 1,
+        ];
+    }
+}

--- a/database/factories/CourseFactory.php
+++ b/database/factories/CourseFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Course;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Course>
+ */
+class CourseFactory extends Factory
+{
+    protected $model = Course::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'title' => $this->faker->sentence(),
+            'description' => $this->faker->paragraph(),
+            'objectives' => $this->faker->sentence(),
+            'thumbnail' => null,
+            'status' => 'draft',
+        ];
+    }
+}

--- a/database/factories/LessonFactory.php
+++ b/database/factories/LessonFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Lesson;
+use App\Models\Course;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Lesson>
+ */
+class LessonFactory extends Factory
+{
+    protected $model = Lesson::class;
+
+    public function definition(): array
+    {
+        return [
+            'course_id' => Course::factory(),
+            'title' => $this->faker->sentence(),
+            'description' => $this->faker->paragraph(),
+            'order' => 1,
+        ];
+    }
+}

--- a/tests/Feature/CourseTest.php
+++ b/tests/Feature/CourseTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Content;
+use App\Models\Course;
+use App\Models\Lesson;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CourseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_course_can_be_created(): void
+    {
+        $course = Course::factory()->create();
+
+        $this->assertDatabaseHas('courses', ['id' => $course->id]);
+    }
+
+    public function test_user_can_enroll_in_course(): void
+    {
+        $course = Course::factory()->create(['status' => 'published']);
+        $user = User::factory()->create();
+
+        $course->enrolledUsers()->attach($user->id);
+
+        $this->assertTrue($course->refresh()->enrolledUsers->contains($user));
+    }
+
+    public function test_enrolled_user_can_access_course_content(): void
+    {
+        $user = User::factory()->create();
+        $course = Course::factory()->create(['status' => 'published']);
+        $lesson = Lesson::factory()->for($course)->create(['order' => 1]);
+        $content = Content::factory()->for($lesson)->create(['order' => 1]);
+
+        $course->enrolledUsers()->attach($user->id);
+
+        $response = $this->actingAs($user)->get(route('contents.show', $content));
+
+        $response->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary
- add factories for Course, Lesson, and Content
- cover course creation, enrollment, and content access in new feature tests

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689990cf86c4832496108a6877de9fc5