### PR TITLE
Use pagination for course listing

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -35,7 +35,7 @@ class CourseController extends Controller
             });
         }
 
-        $courses = $query->with('instructors')->latest()->get();
+        $courses = $query->with('instructors')->latest()->paginate(10);
 
         return view('courses.index', compact('courses'));
     }

--- a/resources/views/courses/index.blade.php
+++ b/resources/views/courses/index.blade.php
@@ -190,12 +190,10 @@
                             @endforeach
                         </div>
 
-                        <!-- Pagination Info (if needed) -->
-                        @if(method_exists($courses, 'links'))
-                            <div class="mt-12">
-                                {{ $courses->links() }}
-                            </div>
-                        @endif
+                        <!-- Pagination -->
+                        <div class="mt-12">
+                            {{ $courses->links() }}
+                        </div>
                     @endif
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- paginate course index results
- show pagination links on course index view

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_689990c5d6d88324923ba72ccb28e577