### PR TITLE
Add pagination to course detail lists

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -200,14 +200,14 @@ class CourseController extends Controller
 
         $availableInstructors = User::role('instructor')
             ->whereNotIn('id', $course->instructors->pluck('id'))
-            ->get();
+            ->paginate(10, ['*'], 'instructors_page');
 
         $unEnrolledParticipants = User::role('participant')
             ->whereDoesntHave('courses', function ($query) use ($course) {
                 $query->where('course_id', $course->id);
             })
             ->orderBy('name')
-            ->get();
+            ->paginate(10, ['*'], 'participants_page');
 
         $availableOrganizers = User::role('event-organizer')
             ->whereNotIn('id', $course->eventOrganizers->pluck('id'))

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -663,7 +663,7 @@
                                     </div>
                                     <div>
                                         <h4 class="text-lg font-bold text-green-900">Tambahkan Instruktur</h4>
-                                        <p class="text-sm text-green-700">{{ $availableInstructors->count() }} instruktur tersedia</p>
+                                        <p class="text-sm text-green-700">{{ $availableInstructors->total() }} instruktur tersedia</p>
                                     </div>
                                 </div>
 
@@ -691,7 +691,12 @@
                                             </div>
                                         @endforelse
                                     </div>
-                                    @if($availableInstructors->isNotEmpty())
+                                    @if($availableInstructors->hasPages())
+                                        <div class="mt-4">
+                                            {{ $availableInstructors->links() }}
+                                        </div>
+                                    @endif
+                                    @if($availableInstructors->total() > 0)
                                         <button type="submit" class="w-full inline-flex justify-center items-center px-4 py-3 bg-green-600 text-white font-semibold rounded-xl hover:bg-green-700 shadow-lg hover:shadow-xl transition-all duration-200">
                                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
@@ -819,7 +824,7 @@
                             selectedUnenrollUsers: [],
                             searchTermEnroll: '',
                             searchTermUnenroll: '',
-                            unEnrolledParticipantsData: {{ Js::from($unEnrolledParticipants) }},
+                            unEnrolledParticipantsData: {{ Js::from($unEnrolledParticipants->items()) }},
                             enrolledParticipantsData: {{ Js::from($course->enrolledUsers) }},
                             get filteredUnEnrolledParticipants() {
                                 if (this.searchTermEnroll === '') return this.unEnrolledParticipantsData;
@@ -927,7 +932,7 @@
                                     </div>
                                     <div>
                                         <h4 class="text-lg font-bold text-emerald-900">Daftarkan Peserta</h4>
-                                        <p class="text-sm text-emerald-700">{{ $unEnrolledParticipants->count() }} calon peserta tersedia</p>
+                                        <p class="text-sm text-emerald-700">{{ $unEnrolledParticipants->total() }} calon peserta tersedia</p>
                                     </div>
                                 </div>
 
@@ -974,6 +979,12 @@
                                             </div>
                                         </template>
                                     </div>
+
+                                    @if($unEnrolledParticipants->hasPages())
+                                        <div class="mt-4">
+                                            {{ $unEnrolledParticipants->links() }}
+                                        </div>
+                                    @endif
 
                                     <button type="submit" x-bind:disabled="selectedEnrollUsers.length === 0"
                                             :class="selectedEnrollUsers.length === 0 ? 'opacity-50 cursor-not-allowed' : ''"


### PR DESCRIPTION
## Summary
- Paginate available instructors and unenrolled participants in course detail view
- Show totals and navigation links for these paginated lists

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689990ce0db88324bc83adc708ed9191