### PR TITLE
feat: add course store request and period service

### DIFF
--- a/app/Http/Requests/StoreCourseRequest.php
+++ b/app/Http/Requests/StoreCourseRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCourseRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'objectives' => 'nullable|string',
+            'thumbnail' => 'nullable|image|max:2048',
+            'status' => 'required|in:draft,published',
+            'certificate_template_id' => 'nullable|exists:certificate_templates,id',
+
+            'enable_periods' => 'nullable|boolean',
+            'periods' => 'nullable|array',
+            'periods.*.name' => 'required_with:periods|string|max:255',
+            'periods.*.start_date' => 'required_with:periods|date|after_or_equal:today',
+            'periods.*.end_date' => 'required_with:periods|date|after:periods.*.start_date',
+            'periods.*.description' => 'nullable|string',
+            'periods.*.max_participants' => 'nullable|integer|min:1',
+
+            'create_default_period' => 'nullable|boolean',
+            'default_start_date' => 'required_if:create_default_period,true|nullable|date|after_or_equal:today',
+            'default_end_date' => 'required_if:create_default_period,true|nullable|date|after:default_start_date',
+        ];
+    }
+}
+

--- a/app/Services/CourseService.php
+++ b/app/Services/CourseService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Course;
+use Carbon\Carbon;
+
+class CourseService
+{
+    /**
+     * Create course periods based on validated data.
+     */
+    public function createCoursePeriods(Course $course, array $data): void
+    {
+        if (!empty($data['create_default_period'])) {
+            $startDate = Carbon::parse($data['default_start_date']);
+            $course->periods()->create([
+                'name' => $course->title . ' - Periode 1',
+                'start_date' => $startDate,
+                'end_date' => Carbon::parse($data['default_end_date']),
+                'status' => $startDate->isToday() || $startDate->isPast() ? 'active' : 'upcoming',
+            ]);
+        }
+
+        if (!empty($data['periods']) && is_array($data['periods'])) {
+            foreach ($data['periods'] as $periodData) {
+                $startDate = Carbon::parse($periodData['start_date']);
+                $course->periods()->create([
+                    'name' => $periodData['name'],
+                    'start_date' => $startDate,
+                    'end_date' => Carbon::parse($periodData['end_date']),
+                    'status' => $startDate->isToday() || $startDate->isPast() ? 'active' : 'upcoming',
+                    'description' => $periodData['description'] ?? null,
+                    'max_participants' => $periodData['max_participants'] ?? null,
+                ]);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add StoreCourseRequest with course validation
- delegate course period creation to CourseService
- use StoreCourseRequest in CourseController store method

## Testing
- `php -l app/Http/Requests/StoreCourseRequest.php`
- `php -l app/Services/CourseService.php`
- `php -l app/Http/Controllers/CourseController.php`
- `phpunit` *(fails: command not found)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689990cefcc083249c961cb1389e6371