### PR TITLE
Restrict course view policy

### DIFF
--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -33,7 +33,11 @@ class CoursePolicy
      */
     public function view(User $user, Course $course): bool
     {
-        if ($user->can('manage own courses') || $user->can('manage all courses')) {
+        if ($user->can('manage all courses')) {
+            return true;
+        }
+
+        if ($user->can('manage own courses') && $course->instructors->contains($user)) {
             return true;
         }
 


### PR DESCRIPTION
## Summary
- require instructors to own a course before `manage own courses` allows viewing

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: curl error 56 while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68999956ee5883249bb02bdc272fabf4