### PR TITLE
Restrict course updates and deletes to privileged role

### DIFF
--- a/app/Policies/CoursePolicy.php
+++ b/app/Policies/CoursePolicy.php
@@ -79,7 +79,7 @@ class CoursePolicy
      */
     public function update(User $user, Course $course): bool
     {
-        return $user->can('manage own courses') && $course->instructors->contains($user);
+        return $user->can('manage all courses');
     }
 
     /**
@@ -87,7 +87,7 @@ class CoursePolicy
      */
     public function delete(User $user, Course $course): bool
     {
-        return $user->can('manage own courses') && $course->instructors->contains($user);
+        return $user->can('manage all courses');
     }
 
     /**


### PR DESCRIPTION
## Summary
- Require `manage all courses` permission to update and delete courses, preventing instructors with only `manage own courses` from modifying or removing them

## Testing
- `composer test` *(fails: require(/workspace/LMSAPP_Laravel_V2/vendor/autoload.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68999957428c832484f890a813844568