### PR TITLE
Allow viewing course discussions with view ability

### DIFF
--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -16,7 +16,7 @@
                     </svg>
                     Kembali ke Daftar Kursus
                 </a>
-                @can('update', $course)
+                @can('view', $course)
                     <a href="{{ route('courses.discussions.index', $course) }}" class="inline-flex items-center px-4 py-2 bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-xl font-medium text-sm hover:from-blue-600 hover:to-blue-700 shadow-lg hover:shadow-xl transition-all duration-200">
                         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>


### PR DESCRIPTION
## Summary
- Relax Diskusi link permission to `view` so course viewers can access discussions

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68999957eb588324b56232d9f3732750