### PR TITLE
Drop user_id from Course model fillable

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -11,7 +11,6 @@ class Course extends Model
     use HasFactory, Duplicateable; // Gunakan Trait
 
     protected $fillable = [
-        'user_id',
         'title',
         'description',
         'objectives',


### PR DESCRIPTION
## Summary
- remove legacy `user_id` field from Course model
- rely on `instructors()` relation using `course_instructor` pivot

## Testing
- `composer test` *(fails: Failed opening required '/workspace/LMSAPP_Laravel_V2/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading symfony/polyfill-mbstring/v1.32.0.zip: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68999d8f550483249065348eae6b1318