### PR TITLE
test: disable Vite in tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,17 @@
 
 namespace Tests;
 
+use Illuminate\Foundation\Testing\Concerns\InteractsWithVite;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use InteractsWithVite;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
## Summary
- disable Vite during tests to avoid missing manifest errors

## Testing
- `composer install` *(fails: curl error 56 while downloading packages)*
- `php artisan test` *(fails: vendor autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68999d8f25788324a34316567a04fa49