### PR TITLE
Remove user reference from CourseFactory and adapt tests to pivot relations

### DIFF
--- a/database/factories/CourseFactory.php
+++ b/database/factories/CourseFactory.php
@@ -3,7 +3,6 @@
 namespace Database\Factories;
 
 use App\Models\Course;
-use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -16,7 +15,6 @@ class CourseFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => User::factory(),
             'title' => $this->faker->sentence(),
             'description' => $this->faker->paragraph(),
             'objectives' => $this->faker->sentence(),

--- a/tests/Feature/CourseTest.php
+++ b/tests/Feature/CourseTest.php
@@ -16,13 +16,18 @@ class CourseTest extends TestCase
     public function test_course_can_be_created(): void
     {
         $course = Course::factory()->create();
+        $instructor = User::factory()->create();
+
+        $course->instructors()->attach($instructor->id);
 
         $this->assertDatabaseHas('courses', ['id' => $course->id]);
     }
 
     public function test_user_can_enroll_in_course(): void
     {
+        $instructor = User::factory()->create();
         $course = Course::factory()->create(['status' => 'published']);
+        $course->instructors()->attach($instructor->id);
         $user = User::factory()->create();
 
         $course->enrolledUsers()->attach($user->id);
@@ -32,8 +37,10 @@ class CourseTest extends TestCase
 
     public function test_enrolled_user_can_access_course_content(): void
     {
+        $instructor = User::factory()->create();
         $user = User::factory()->create();
         $course = Course::factory()->create(['status' => 'published']);
+        $course->instructors()->attach($instructor->id);
         $lesson = Lesson::factory()->for($course)->create(['order' => 1]);
         $content = Content::factory()->for($lesson)->create(['order' => 1]);
 


### PR DESCRIPTION
## Summary
- drop automatic user creation from `CourseFactory`
- update course feature tests to attach instructors via `course_instructor` pivot

## Testing
- `composer install --no-progress` *(fails: curl error 56 while downloading package, CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68999d8f0bc883249f5e0d8df7eb00a0