### PR TITLE
Remove InteractsWithVite trait from TestCase

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,13 +2,10 @@
 
 namespace Tests;
 
-use Illuminate\Foundation\Testing\Concerns\InteractsWithVite;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    use InteractsWithVite;
-
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
## Summary
- drop deprecated InteractsWithVite trait from `tests/TestCase`

## Testing
- `php artisan test` *(fails: require vendor/autoload.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68999ff7581c8324b71aa2257f683c51