### PR TITLE
Add guest access restriction test for course content

### DIFF
--- a/tests/Feature/CourseTest.php
+++ b/tests/Feature/CourseTest.php
@@ -50,4 +50,17 @@ class CourseTest extends TestCase
 
         $response->assertOk();
     }
+
+    public function test_guest_cannot_access_course_content(): void
+    {
+        $instructor = User::factory()->create();
+        $course = Course::factory()->create(['status' => 'published']);
+        $course->instructors()->attach($instructor->id);
+        $lesson = Lesson::factory()->for($course)->create(['order' => 1]);
+        $content = Content::factory()->for($lesson)->create(['order' => 1]);
+
+        $response = $this->get(route('contents.show', $content));
+
+        $response->assertRedirect(route('login'));
+    }
 }


### PR DESCRIPTION
## Summary
- add feature test ensuring guests are redirected to login when accessing course content

## Testing
- `composer install` *(failed: curl error 56 while downloading, CONNECT tunnel failed with response 403)*
- `php artisan test tests/Feature/CourseTest.php` *(failed: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_6899a63611b08324a15409d41b413a8e