### PR TITLE
test: add lesson CRUD feature tests

### DIFF
--- a/tests/Feature/LessonTest.php
+++ b/tests/Feature/LessonTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Lesson;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LessonTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lesson_can_be_created(): void
+    {
+        $lesson = Lesson::factory()->create();
+
+        $this->assertDatabaseHas('lessons', [
+            'id' => $lesson->id,
+            'title' => $lesson->title,
+        ]);
+    }
+
+    public function test_lesson_can_be_updated(): void
+    {
+        $lesson = Lesson::factory()->create();
+
+        $lesson->update(['title' => 'Updated Title']);
+
+        $this->assertDatabaseHas('lessons', [
+            'id' => $lesson->id,
+            'title' => 'Updated Title',
+        ]);
+    }
+
+    public function test_lesson_can_be_deleted(): void
+    {
+        $lesson = Lesson::factory()->create();
+
+        $lesson->delete();
+
+        $this->assertModelMissing($lesson);
+    }
+}


### PR DESCRIPTION
## Summary
- add feature tests for creating, updating, and deleting lessons using factory and database assertions

## Testing
- `php artisan test --testsuite=Feature tests/Feature/LessonTest.php` *(fails: require vendor/autoload.php - missing dependencies due to failed composer install)*

------
https://chatgpt.com/codex/tasks/task_e_6899a63767f08324b1432da01b3c0ad6