### PR TITLE
test: verify registration authenticates user

### DIFF
--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -25,7 +26,13 @@ class RegistrationTest extends TestCase
             'password_confirmation' => 'password',
         ]);
 
-        $this->assertAuthenticated();
+        $this->assertDatabaseHas('users', [
+            'email' => 'test@example.com',
+        ]);
+
+        $user = User::where('email', 'test@example.com')->first();
+
+        $this->assertAuthenticatedAs($user);
         $response->assertRedirect(route('dashboard', absolute: false));
     }
 }


### PR DESCRIPTION
## Summary
- verify new registration stored in database and authenticates the same user

## Testing
- `composer install --no-interaction --prefer-dist --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit tests/Feature/Auth/RegistrationTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899a63872d0832486ef00d151aa7e74