### PR TITLE
Add guest password update edge case test

### DIFF
--- a/tests/Feature/Auth/PasswordUpdateTest.php
+++ b/tests/Feature/Auth/PasswordUpdateTest.php
@@ -48,4 +48,21 @@ class PasswordUpdateTest extends TestCase
             ->assertSessionHasErrorsIn('updatePassword', 'current_password')
             ->assertRedirect('/profile');
     }
+
+    public function test_guests_cannot_update_password(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+        $this->post('/logout');
+
+        $response = $this->put('/password', [
+            'current_password' => 'password',
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+        ]);
+
+        $response->assertRedirect('/login');
+        $this->assertGuest();
+    }
 }


### PR DESCRIPTION
## Summary
- add failing edge-case test ensuring guests cannot update passwords

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_6899a63a2b488324a23232f6e9624425